### PR TITLE
feat: log info of sidekiq processes when OOM killed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,5 @@ group :coverage do
   gem "simplecov",      "~> 0.12.0"
   gem "simplecov-json", "~> 0.2"
 end
+
+gem 'log4r'

--- a/sidekiq-worker-killer.gemspec
+++ b/sidekiq-worker-killer.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency("rspec", "~> 3.5")
   s.add_development_dependency("rubocop", "~> 0.49.1")
+  s.add_development_dependency("pry")
 end

--- a/spec/sidekiq/worker_killer_spec.rb
+++ b/spec/sidekiq/worker_killer_spec.rb
@@ -30,6 +30,8 @@ describe Sidekiq::WorkerKiller do
 
       before do
         allow(subject).to receive(:current_rss).and_return(3)
+        allow(job).to receive(:[]).with('jid').and_return(4)
+        allow(job).to receive(:[]).with('args').and_return(5)
       end
 
       it "should request shutdown" do


### PR DESCRIPTION
We want to know if there is a pattern behind all the sidekiq
processes that suddenly consume large amounts of memory (which
used to crash the whole node, but now the offending PID just gets
killed). As a first pass towards solving the problem, this commit
introduces a logger to capture sidekiq job info (for further
investigation on the notification associated with the process)
before killing the PID.

OneSignal (rails) repo will need to be updated to use this fork, see
https://github.com/OneSignal/OneSignal/pull/6585