### PR TITLE
fix: add timestamp to Log4r output when killing processes

### DIFF
--- a/lib/sidekiq/worker_killer.rb
+++ b/lib/sidekiq/worker_killer.rb
@@ -71,7 +71,7 @@ class Sidekiq::WorkerKiller
                                         :trunc=>false,
                                         :level=>Log4r::FATAL)
     # Note: logger.fatal won't kill the process
-    logger.fatal "Process #{::Process.pid} killed (OOM) at #{Time.now}. JID: #{job['jid']}, Job: #{worker.class.name}, Args: #{job['args']}"
+    logger.fatal "Process #{::Process.pid} killed (OOM) at #{Time.current}. JID: #{job['jid']}, Job: #{worker.class.name}, Args: #{job['args']}"
 
     request_shutdown
   end

--- a/lib/sidekiq/worker_killer.rb
+++ b/lib/sidekiq/worker_killer.rb
@@ -71,7 +71,7 @@ class Sidekiq::WorkerKiller
                                         :trunc=>false,
                                         :level=>Log4r::FATAL)
     # Note: logger.fatal won't kill the process
-    logger.fatal "Process #{::Process.pid} killed (OOM). JID: #{job['jid']}, Job: #{worker.class.name}, Args: #{job['args']}"
+    logger.fatal "Process #{::Process.pid} killed (OOM) at #{Time.now}. JID: #{job['jid']}, Job: #{worker.class.name}, Args: #{job['args']}"
 
     request_shutdown
   end


### PR DESCRIPTION
Missed from initial logging commit. Having timestamps would be very
helpful in establishing a history of when sidekiq processes failed
or started to fail.