### PR TITLE
fix: getting ioerror when getting process mem size

### DIFF
--- a/lib/sidekiq/worker_killer/version.rb
+++ b/lib/sidekiq/worker_killer/version.rb
@@ -1,7 +1,7 @@
 # rubocop:disable Style/ClassAndModuleChildren
 module Sidekiq
   class WorkerKiller
-    VERSION = "1.0.0".freeze
+    VERSION = "1.1.0".freeze
   end
 end
 # rubocop:enable Style/ClassAndModuleChildren


### PR DESCRIPTION
I manually tested current_rss works by writing

```diff
  def current_rss
+   raise IOError
    ::GetProcessMem.new.mb
```

And checked that all the tests passed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/sidekiq-worker-killer/3)
<!-- Reviewable:end -->
